### PR TITLE
[fix] pass the write stream callback so that we can communicate backp…

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ TransportStream.prototype._write = function (info, enc, callback) {
   // conditionally write to our pipe targets as stream.
   //
   if (!this.level || this.levels[this.level] <= this.levels[info.level]) {
-    this.log(info);
+    return this.log(info, callback);
   }
 
   callback();


### PR DESCRIPTION
…ressure up the chain of streams. Thoughts @indexzero ? This would require all `.log` functions implemented via transports to call the callback but would allow back-pressure to work properly so memory doesnt get overloaded.