### PR TITLE
winston 1245 restore silent option (base transport)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for winston-transport 3.0
+// Project: https://github.com/winstonjs/winston-transport
+// Definitions by: DABH <https://github.com/DABH>
+// Definitions: https://github.com/winstonjs/winston-transport
+
+/// <reference types="node" />
+
+import * as stream from 'stream';
+import * as logform from 'logform';
+
+interface TransportStreamOptions {
+  level?: string;
+  format?: logform.Format;
+  handleExceptions?: boolean;
+  log?: (info: any, next: () => void) => any;
+  logv?: (info: any, next: () => void) => any;
+  close?: () => void;
+}
+
+declare class TransportStream extends stream.Writable {
+  format?: logform.Format;
+  level?: string;
+  handleExceptions?: boolean;
+  log?: (info: any, next: () => void) => any;
+  logv?: (info: any, next: () => void) => any;
+  close?: () => void;
+
+  constructor(opts: TransportStreamOptions);
+  constructor();
+
+}

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var TransportStream = module.exports = function TransportStream(opts) {
   this.format = opts.format;
   this.level = opts.level;
   this.handleExceptions = opts.handleExceptions;
+  this.silent = opts.silent;
 
   if (opts.log) this.log = opts.log;
   if (opts.logv) this.logv = opts.logv;
@@ -69,7 +70,8 @@ util.inherits(TransportStream, stream.Writable);
  * Writes the info object to our transport instance.
  */
 TransportStream.prototype._write = function (info, enc, callback) {
-  if (info.exception === true && !this.handleExceptions) {
+  if ((info.exception === true && !this.handleExceptions) ||
+      this.silent) {
     return callback(null);
   }
 
@@ -121,7 +123,7 @@ TransportStream.prototype._accept = function (write) {
   //
   // Immediately check the average case: log level filtering.
   //
-  if (info.exception === true || !this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
+  if (info.exception === true || !this.level || this.levels[this.level] >= this.levels[info[LEVEL]] || this.silent) {
     //
     // Ensure the info object is valid based on `{ exception }`:
     // 1. { handleExceptions: true }: all `info` objects are valid

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "devDependencies": {
     "abstract-winston-transport": ">= 0.3.0",
     "assume": "^1.4.1",
-    "logform": "^1.1.0",
+    "logform": "^1.4.0",
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
-    "winston-compat": "0.0.1"
+    "winston-compat": "0.1.0",
+    "@types/node": "^9.6.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "baseUrl": "./",
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules"
+    ],
+    "types": ["node", "logform"],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts"
+  ]
+}


### PR DESCRIPTION
Adds `silent` as property of the base `TransportStream` and checks `silent` when streaming.  Seems to not matter when a specific transport calls `log` / bypassing the streaming -- in that case it seems the stream's `log` must check for `this.silent` explicitly on its own...

See https://github.com/winstonjs/winston/pull/1230 , https://github.com/winstonjs/winston/issues/1245