### PR TITLE
Revice d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,24 +8,28 @@
 import * as stream from 'stream';
 import * as logform from 'logform';
 
-interface TransportStreamOptions {
-  level?: string;
-  format?: logform.Format;
-  handleExceptions?: boolean;
-  log?: (info: any, next: () => void) => any;
-  logv?: (info: any, next: () => void) => any;
-  close?: () => void;
+declare namespace TransportStream {
+  interface TransportStreamOptions {
+    format?: logform.Format;
+    level?: string;
+    handleExceptions?: boolean;
+
+    log?(info: any, next: () => void): any;
+    logv?(info: any, next: () => void): any;
+    close?(): void;
+  }
 }
 
 declare class TransportStream extends stream.Writable {
-  format?: logform.Format;
-  level?: string;
-  handleExceptions?: boolean;
-  log?: (info: any, next: () => void) => any;
-  logv?: (info: any, next: () => void) => any;
-  close?: () => void;
+  public format?: logform.Format;
+  public level?: string;
+  public handleExceptions?: boolean;
 
-  constructor(opts: TransportStreamOptions);
-  constructor();
+  constructor(opts?: TransportStream.TransportStreamOptions);
 
+  public log?(info: any, next: () => void): any;
+  public logv?(info: any, next: () => void): any;
+  public close?(): void;
 }
+
+export = TransportStream;


### PR DESCRIPTION
Exports TransportStream class as a single object, and revices properties.

Sample typescript file:
```
import * as Transport from "winston-transport";

class MyTransport extends Transport {
    public constructor(options?: Transport.TransportStreamOptions) {
        super(options);
    }

    public log(info: any, callback?: () => void) {
        setImmediate(() => {
            this.emit('logged', info);
        });

        if (callback) {
            callback();
        }
    }
}
```

Output javascript file using `tsc --target es6 --module commonjs index.ts` command:
```
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const Transport = require("winston-transport");
class MyTransport extends Transport {
    constructor(options) {
        super(options);
    }
    log(info, callback) {
        setImmediate(() => {
            this.emit('logged', info);
        });
        if (callback) {
            callback();
        }
    }
}
```
