### PR TITLE
Ensure format is respected in _writev. Fixes #12.

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -71,7 +71,8 @@ LegacyTransportStream.prototype._write = function (info, enc, callback) {
 LegacyTransportStream.prototype._writev = function (chunks, callback) {
   for (var i = 0; i < chunks.length; i++) {
     if (this._accept(chunks[i])) {
-      this.transport.log(chunks[i].chunk[LEVEL], chunks[i].chunk.message, chunks[i].chunk, chunks[i].callback);
+      this.transport.log(chunks[i].chunk[LEVEL], chunks[i].chunk.message, chunks[i].chunk, this._nop);
+      chunks[i].callback();
     }
   }
 

--- a/legacy.js
+++ b/legacy.js
@@ -69,14 +69,10 @@ LegacyTransportStream.prototype._write = function (info, enc, callback) {
  * after performing any necessary filtering.
  */
 LegacyTransportStream.prototype._writev = function (chunks, callback) {
-  const infos = chunks.filter(this._accept, this);
-  if (!infos.length) {
-    return callback(null);
-  }
-
-  for (var i = 0; i < infos.length; i++) {
-    this.transport.log(infos[i].chunk[LEVEL], infos[i].chunk.message, infos[i].chunk, this._nop);
-    infos[i].callback();
+  for (var i = 0; i < chunks.length; i++) {
+    if (this._accept(chunks[i])) {
+      this.transport.log(chunks[i].chunk[LEVEL], chunks[i].chunk.message, chunks[i].chunk, chunks[i].callback);
+    }
   }
 
   return callback(null);


### PR DESCRIPTION
This PR does the following:

- [x] Ensures that `this.format` is applied to all `info` objects before calling `.log` in `TransportStream.prototype._write`.
- [x] Back-port the technique in `_writev` to `LegacyTransportStream` that avoids a shallow copy of the original `chunks` array.
- [x] Add test coverage for the scenario.