### PR TITLE
[refactor] Update transports to use ES6 classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,164 +1,171 @@
 'use strict';
 
-const stream = require('stream');
-const util = require('util');
+const { Writable } = require('stream');
 const LEVEL = Symbol.for('level');
 
-/**
- * Constructor function for the TransportStream. This is the base prototype
- * that all `winston >= 3` transports should inherit from.
- *
- * @param  {Object} opts Options for this TransportStream instance
- *   @param {String} opts.level HIGHEST level according to RFC5424.
- *   @param {Boolean} opts.handleExceptions If true, info with { exception: true } will be written.
- *   @param {Function} opts.log Custom log function for simple Transport creation
- *   @param {Function} opts.close Called on "unpipe" from parent
- */
-var TransportStream = module.exports = function TransportStream(opts) {
-  stream.Writable.call(this, { objectMode: true });
-  opts = opts || {};
+module.exports = class TransportStream extends Writable {
+  /**
+   * Constructor function for the TransportStream. This is the base prototype
+   * that all `winston >= 3` transports should inherit from.
+   * @param {Object} options - Options for this TransportStream instance
+   * @param {String} options.level - Highest level according to RFC5424.
+   * @param {Boolean} options.handleExceptions - If true, info with
+   * { exception: true } will be written.
+   * @param {Function} options.log - Custom log function for simple Transport
+   * creation
+   * @param {Function} options.close - Called on "unpipe" from parent.
+   */
+  constructor(options = {}) {
+    super({
+      objectMode: true
+    });
 
-  this.format = opts.format;
-  this.level = opts.level;
-  this.handleExceptions = opts.handleExceptions;
-  this.silent = opts.silent;
+    this.format = options.format;
+    this.level = options.level;
+    this.handleExceptions = options.handleExceptions;
+    this.silent = options.silent;
 
-  if (opts.log) this.log = opts.log;
-  if (opts.logv) this.logv = opts.logv;
-  if (opts.close) this.close = opts.close;
+    if (options.log) {
+      this.log = options.log;
+    }
+    if (options.logv) {
+      this.logv = options.logv;
+    }
+    if (options.close) {
+      this.close = options.close;
+    }
 
-  var self = this;
+    // Get the levels from the source we are piped from.
+    this.once('pipe', logger => {
+      // Remark (indexzero): this bookkeeping can only support multiple
+      // Logger parents with the same `levels`. This comes into play in
+      // the `winston.Container` code in which `container.add` takes
+      // a fully realized set of options with pre-constructed TransportStreams.
+      this.levels = logger.levels;
+      this.level = this.level || logger.level;
+      this.parent = logger;
+    });
 
-  //
-  // Get the levels from the source we are piped from.
-  //
-  this.once('pipe', function (logger) {
-    //
-    // Remark (indexzero): this bookkeeping can only support multiple
-    // Logger parents with the same `levels`. This comes into play in
-    // the `winston.Container` code in which `container.add` takes
-    // a fully realized set of options with pre-constructed TransportStreams.
-    //
-    self.levels = logger.levels;
-    self.level = self.level || logger.level;
-    self.parent = logger;
-  });
-
-  //
-  // If and/or when the transport is removed from this instance
-  //
-  this.once('unpipe', function (src) {
-    //
-    // Remark (indexzero): this bookkeeping can only support multiple
-    // Logger parents with the same `levels`. This comes into play in
-    // the `winston.Container` code in which `container.add` takes
-    // a fully realized set of options with pre-constructed TransportStreams.
-    //
-    if (src === self.parent) {
-      this.parent = null;
-      if (self.close) {
-        self.close();
+    // If and/or when the transport is removed from this instance
+    this.once('unpipe', src => {
+      // Remark (indexzero): this bookkeeping can only support multiple
+      // Logger parents with the same `levels`. This comes into play in
+      // the `winston.Container` code in which `container.add` takes
+      // a fully realized set of options with pre-constructed TransportStreams.
+      if (src === this.parent) {
+        this.parent = null;
+        if (this.close) {
+          this.close();
+        }
       }
-    }
-  });
-};
-
-util.inherits(TransportStream, stream.Writable);
-
-/*
- * @private function _write(info)
- * Writes the info object to our transport instance.
- */
-TransportStream.prototype._write = function (info, enc, callback) {
-  if (this.silent || (info.exception === true && !this.handleExceptions)) {
-    return callback(null);
+    });
   }
 
-  //
-  // Remark: This has to be handled in the base transport now because we cannot
-  // conditionally write to our pipe targets as stream.
-  //
-  if (!this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
-    if (this.format) {
-      return this.log(
-        this.format.transform(Object.assign({}, info), this.format.options),
-        callback
-      );
-    }
-
-    return this.log(info, callback);
-  }
-
-  return callback(null);
-};
-
-/*
- * @private function _writev(chunks, callback)
- * Writes the batch of info objects (i.e. "object chunks") to our transport instance
- * after performing any necessary filtering.
- */
-TransportStream.prototype._writev = function (chunks, callback) {
-  if (this.logv) {
-    const infos = chunks.filter(this._accept, this);
-    if (!infos.length) {
+  /**
+   * Writes the info object to our transport instance.
+   * @param {mixed} info - TODO: add param description.
+   * @param {mixed} enc - TODO: add param description.
+   * @param {function} callback - TODO: add param description.
+   * @returns {undefined}
+   * @private
+   */
+  _write(info, enc, callback) {
+    if (this.silent || (info.exception === true && !this.handleExceptions)) {
       return callback(null);
     }
 
-    // Remark (indexzero): from a performance perspective if Transport
-    // implementers do choose to implement logv should we make it their
-    // responsibility to invoke their format?
-    return this.logv(infos, callback);
+    // Remark: This has to be handled in the base transport now because we
+    // cannot conditionally write to our pipe targets as stream.
+    if (!this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
+      if (this.format) {
+        return this.log(
+          this.format.transform(Object.assign({}, info), this.format.options),
+          callback
+        );
+      }
+
+      return this.log(info, callback);
+    }
+
+    return callback(null);
   }
 
-  for (var i = 0; i < chunks.length; i++) {
-    if (this._accept(chunks[i])) {
-      if (this.format) {
-        this.log(
-          this.format.transform(Object.assign({}, chunks[i].chunk), this.format.options),
-          chunks[i].callback
-        );
-      } else {
-        this.log(chunks[i].chunk, chunks[i].callback);
+  /**
+   * Writes the batch of info objects (i.e. "object chunks") to our transport
+   * instance after performing any necessary filtering.
+   * @param {mixed} chunks - TODO: add params description.
+   * @param {function} callback - TODO: add params description.
+   * @private
+   */
+  _writev(chunks, callback) {
+    if (this.logv) {
+      const infos = chunks.filter(this._accept, this);
+      if (!infos.length) {
+        return callback(null);
+      }
+
+      // Remark (indexzero): from a performance perspective if Transport
+      // implementers do choose to implement logv should we make it their
+      // responsibility to invoke their format?
+      return this.logv(infos, callback);
+    }
+
+    for (let i = 0; i < chunks.length; i++) {
+      if (this._accept(chunks[i])) {
+        if (this.format) {
+          this.log(
+            this.format.transform(
+              Object.assign({}, chunks[i].chunk),
+              this.format.options
+            ),
+            chunks[i].callback
+          );
+        } else {
+          this.log(chunks[i].chunk, chunks[i].callback);
+        }
       }
     }
+
+    return callback(null);
   }
 
-  return callback(null);
-};
+  /**
+   * Predicate function that returns true if the specfied `info` on the
+   * WriteReq, `write`, should be passed down into the derived
+   * TransportStream's I/O via `.log(info, callback)`.
+   * @param {WriteReq} write - winston@3 Node.js WriteReq for the `info` object
+   * representing the log message.
+   * @returns {Boolean} - Value indicating if the `write` should be accepted &
+   * logged.
+   */
+  _accept(write) {
+    const info = write.chunk;
+    if (this.silent) {
+      return false;
+    }
 
-/**
- * Predicate function that returns true if the specfied `info` on the WriteReq, `write`, should
- * be passed down into the derived TransportStream's I/O via `.log(info, callback)`.
- * @param   {WriteReq} write winston@3 Node.js WriteReq for the `info` object representing the log message.
- * @returns {Boolean} Value indicating if the `write` should be accepted & logged.
- */
-TransportStream.prototype._accept = function (write) {
-  const info = write.chunk;
-  if (this.silent) {
+    // Immediately check the average case: log level filtering.
+    if (
+      info.exception === true ||
+      !this.level ||
+      this.levels[this.level] >= this.levels[info[LEVEL]]
+    ) {
+      // Ensure the info object is valid based on `{ exception }`:
+      // 1. { handleExceptions: true }: all `info` objects are valid
+      // 2. { exception: false }: accepted by all transports.
+      if (this.handleExceptions || info.exception !== true) {
+        return true;
+      }
+    }
+
     return false;
   }
 
-  //
-  // Immediately check the average case: log level filtering.
-  //
-  if (info.exception === true || !this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
-    //
-    // Ensure the info object is valid based on `{ exception }`:
-    // 1. { handleExceptions: true }: all `info` objects are valid
-    // 2. { exception: false }: accepted by all transports.
-    //
-    if (this.handleExceptions || info.exception !== true) {
-      return true;
-    }
+  /**
+   * _nop is short for "No operation"
+   * @return {Boolean} Intentionally false.
+   */
+  _nop() {
+    return void undefined;
   }
-
-  return false;
-};
-
-/**
- * _nop is short for "No operation"
- * @return {Boolean} Intentionally false.
- */
-TransportStream.prototype._nop = function () {
-  return void undefined;
-};
+}

--- a/legacy.js
+++ b/legacy.js
@@ -1,105 +1,113 @@
 'use strict';
 
-const util = require('util');
 const TransportStream = require('./');
 const LEVEL = Symbol.for('level');
 
-/**
- * Constructor function for the LegacyTransportStream. This is an internal wrapper
- * `winston >= 3` uses to wrap older transports implementing log(level, message, meta).
- *
- * @param  {Object} opts Options for this TransportStream instance.
- *   @param {Transpot} opts.transport winston@2 or older Transport to wrap.
- */
-var LegacyTransportStream = module.exports = function LegacyTransportStream(opts) {
-  opts = opts || {};
-  if (!opts.transport || typeof opts.transport.log !== 'function') {
-    throw new Error('Invalid transport, must be an object with a log method.');
-  }
+module.exports = class LegacyTransportStream extends TransportStream {
+  /**
+   * Constructor function for the LegacyTransportStream. This is an internal
+   * wrapper `winston >= 3` uses to wrap older transports implementing
+   * log(level, message, meta).
+   * @param {Object} options - Options for this TransportStream instance.
+   * @param {Transpot} options.transport - winston@2 or older Transport to wrap.
+   */
+  constructor(options = {}) {
+    super(options);
+    if (!options.transport || typeof options.transport.log !== 'function') {
+      throw new Error('Invalid transport, must be an object with a log method.');
+    }
 
-  TransportStream.call(this, opts);
+    this.transport = options.transport;
+    this.level = this.level || options.transport.level;
+    this.handleExceptions = this.handleExceptions || options.transport.handleExceptions;
 
-  var self = this;
-  this.transport = opts.transport;
-  this.level = this.level || opts.transport.level;
-  this.handleExceptions = this.handleExceptions || opts.transport.handleExceptions;
+    // Display our deprecation notice.
+    this._deprecated();
 
-  // Display our deprecation notice.
-  this._deprecated();
+    // Properly bubble up errors from the transport to the
+    // LegacyTransportStream instance, but only once no matter how many times
+    // this transport is shared.
+    function transportError(err) {
+      this.emit('error', err, this.transport);
+    }
 
-  //
-  // Properly bubble up errors from the transport to the LegacyTransportStream
-  // instance, but only once no matter how many times this transport is shared.
-  //
-  function transportError(err) {
-    self.emit('error', err, self.transport);
-  }
-
-  if (!this.transport.__winstonError) {
-    this.transport.__winstonError = transportError;
-    this.transport.on('error', this.transport.__winstonError);
-  }
-};
-
-util.inherits(LegacyTransportStream, TransportStream);
-
-/*
- * @private function _write(info)
- * Writes the info object to our transport instance.
- */
-LegacyTransportStream.prototype._write = function (info, enc, callback) {
-  if (this.silent || (info.exception === true && !this.handleExceptions)) {
-    return callback(null);
-  }
-
-  //
-  // Remark: This has to be handled in the base transport now because we cannot
-  // conditionally write to our pipe targets as stream.
-  //
-  if (!this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
-    this.transport.log(info[LEVEL], info.message, info, this._nop);
-  }
-
-  callback(null);
-};
-
-/*
- * @private function _writev(chunks, callback)
- * Writes the batch of info objects (i.e. "object chunks") to our transport instance
- * after performing any necessary filtering.
- */
-LegacyTransportStream.prototype._writev = function (chunks, callback) {
-  for (var i = 0; i < chunks.length; i++) {
-    if (this._accept(chunks[i])) {
-      this.transport.log(chunks[i].chunk[LEVEL], chunks[i].chunk.message, chunks[i].chunk, this._nop);
-      chunks[i].callback();
+    if (!this.transport.__winstonError) {
+      this.transport.__winstonError = transportError.bind(this);
+      this.transport.on('error', this.transport.__winstonError);
     }
   }
 
-  return callback(null);
-};
 
-/**
- * Displays a deprecation notice. Defined as a function so it can be overriden in tests.
- */
-LegacyTransportStream.prototype._deprecated = function () {
-  console.error([
-    `${this.transport.name} is a legacy winston transport. Consider upgrading: `,
-    '- Upgrade docs: https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md'
-  ].join('\n'));
-};
+  /**
+   * Writes the info object to our transport instance.
+   * @param {mixed} info - TODO: add param description.
+   * @param {mixed} enc - TODO: add param description.
+   * @param {function} callback - TODO: add param description.
+   * @returns {undefined}
+   * @private
+   */
+  _write(info, enc, callback) {
+    if (this.silent || (info.exception === true && !this.handleExceptions)) {
+      return callback(null);
+    }
 
-/*
- * Clean up error handling state on the legacy transport associated
- * with this instance.
- */
-LegacyTransportStream.prototype.close = function () {
-  if (this.transport.close) {
-    this.transport.close();
+    // Remark: This has to be handled in the base transport now because we
+    // cannot conditionally write to our pipe targets as stream.
+    if (!this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
+      this.transport.log(info[LEVEL], info.message, info, this._nop);
+    }
+
+    callback(null);
   }
 
-  if (this.transport.__winstonError) {
-    this.transport.removeListener('error', this.transport.__winstonError);
-    this.transport.__winstonError = null;
+  /**
+   * Writes the batch of info objects (i.e. "object chunks") to our transport
+   * instance after performing any necessary filtering.
+   * @param {mixed} chunks - TODO: add params description.
+   * @param {function} callback - TODO: add params description.
+   * @private
+   */
+  _writev(chunks, callback) {
+    for (let i = 0; i < chunks.length; i++) {
+      if (this._accept(chunks[i])) {
+        this.transport.log(
+          chunks[i].chunk[LEVEL],
+          chunks[i].chunk.message,
+          chunks[i].chunk,
+          this._nop
+        );
+        chunks[i].callback();
+      }
+    }
+
+    return callback(null);
+  }
+
+  /**
+   * Displays a deprecation notice. Defined as a function so it can be
+   * overriden in tests.
+   * @returns {undefined}
+   */
+  _deprecated() {
+    console.error([
+      `${this.transport.name} is a legacy winston transport. Consider upgrading: `,
+      '- Upgrade docs: https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md'
+    ].join('\n'));
+  };
+
+  /**
+   * Clean up error handling state on the legacy transport associated
+   * with this instance.
+   * @returns {undefined}
+   */
+  close() {
+    if (this.transport.close) {
+      this.transport.close();
+    }
+
+    if (this.transport.__winstonError) {
+      this.transport.removeListener('error', this.transport.__winstonError);
+      this.transport.__winstonError = null;
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "nyc": "^11.6.0",
     "winston-compat": "0.1.0",
     "@types/node": "^9.6.1"
+  },
+  "engines": {
+    "node": ">= 6.4.0"
   }
 }


### PR DESCRIPTION
Changes in this PR:
 - Converted `TransportStream` and `LegacyTransportStream` to use ES6 classes.
 - Removed `self` variables.
 - Add `node >= 6.4.0` to `engines` in `package.json`.