### PR TITLE
 [refactor] Use triple-beam for info object constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Writable } = require('stream');
-const LEVEL = Symbol.for('level');
+const { LEVEL } = require('triple-beam');
 
 module.exports = class TransportStream extends Writable {
   /**

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = class TransportStream extends Writable {
    * instance after performing any necessary filtering.
    * @param {mixed} chunks - TODO: add params description.
    * @param {function} callback - TODO: add params description.
+   * @returns {mixed} - TODO: add returns description.
    * @private
    */
   _writev(chunks, callback) {
@@ -169,4 +170,4 @@ module.exports = class TransportStream extends Writable {
     // eslint-disable-next-line no-undefined
     return void undefined;
   }
-}
+};

--- a/legacy.js
+++ b/legacy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const TransportStream = require('./');
-const LEVEL = Symbol.for('level');
+const { LEVEL } = require('triple-beam');
 
 module.exports = class LegacyTransportStream extends TransportStream {
   /**

--- a/legacy.js
+++ b/legacy.js
@@ -65,6 +65,7 @@ module.exports = class LegacyTransportStream extends TransportStream {
    * instance after performing any necessary filtering.
    * @param {mixed} chunks - TODO: add params description.
    * @param {function} callback - TODO: add params description.
+   * @returns {mixed} - TODO: add returns description.
    * @private
    */
   _writev(chunks, callback) {
@@ -89,11 +90,12 @@ module.exports = class LegacyTransportStream extends TransportStream {
    * @returns {undefined}
    */
   _deprecated() {
+    // eslint-disable-next-line no-console
     console.error([
       `${this.transport.name} is a legacy winston transport. Consider upgrading: `,
       '- Upgrade docs: https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md'
     ].join('\n'));
-  };
+  }
 
   /**
    * Clean up error handling state on the legacy transport associated

--- a/package-lock.json
+++ b/package-lock.json
@@ -4730,6 +4730,11 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "triple-beam": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.2.0.tgz",
+      "integrity": "sha512-nw1CkXiwTt0sdF0i+MRTvslFK7pme9sPGY1MjuZV14HB/pLL3Srw9LsphR1Qo0SYDPMFetpcY/bA3DjPA+R+1g=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/winstonjs/winston-transport/issues"
   },
   "homepage": "https://github.com/winstonjs/winston-transport#readme",
+  "dependencies": {
+    "triple-beam": "^1.2.0"
+  },
   "devDependencies": {
     "@types/node": "^9.6.1",
     "abstract-winston-transport": ">= 0.3.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,8 +15,7 @@ const {
   toWriteReq
 } = require('abstract-winston-transport/utils');
 
-const LEVEL = Symbol.for('level');
-const MESSAGE = Symbol.for('message');
+const { LEVEL, MESSAGE } = require('triple-beam');
 
 describe('TransportStream', function () {
   it('should have the appropriate methods defined', function () {

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -8,7 +8,7 @@ const Parent = require('./fixtures/parent');
 const LegacyTransport = require('./fixtures/legacy-transport');
 const { testLevels, testOrder } = require('./fixtures');
 const { infosFor, logFor, levelAndMessage } = require('abstract-winston-transport/utils');
-const LEVEL = Symbol.for('level');
+const { LEVEL } = require('triple-beam');
 
 //
 // Silence the deprecation notice for sanity in test output.


### PR DESCRIPTION
Replace `const LEVEL = Symbol.for('level');` with `const { LEVEL } = require('triple-beam');`. Same for `MESSAGE`.