### PR TITLE
Use `readable-stream` package to get the _final semantics across all versions of Node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const util = require('util');
-const { Writable } = require('stream');
+const Writable = require('readable-stream/writable');
 const { LEVEL } = require('triple-beam');
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -432,8 +432,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1050,8 +1049,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1159,8 +1157,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4231,8 +4228,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -4293,7 +4289,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4384,8 +4379,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4493,7 +4487,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4609,8 +4602,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/winstonjs/winston-transport#readme",
   "dependencies": {
+    "readable-stream": "^2.3.6",
     "triple-beam": "^1.2.0"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@
 
 const assume = require('assume');
 const { format } = require('logform');
-const stream = require('stream');
+const Writable = require('readable-stream/writable');
 const TransportStream = require('../');
 const Parent = require('./fixtures/parent');
 const { testLevels, testOrder } = require('./fixtures');
@@ -19,7 +19,7 @@ const { LEVEL, MESSAGE } = require('triple-beam');
 describe('TransportStream', () => {
   it('should have the appropriate methods defined', () => {
     const transport = new TransportStream();
-    assume(transport).instanceof(stream.Writable);
+    assume(transport).instanceof(Writable);
     assume(transport._write).is.a('function');
     // eslint-disable-next-line no-undefined
     assume(transport.log).equals(undefined);

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assume = require('assume');
-const stream = require('stream');
+const Writable = require('readable-stream/writable');
 const LegacyTransportStream = require('../legacy');
 const LegacyTransport = require('./fixtures/legacy-transport');
 const { testLevels, testOrder } = require('./fixtures');
@@ -35,7 +35,7 @@ describe('LegacyTransportStream', () => {
   });
 
   it('should have the appropriate methods defined', () => {
-    assume(transport).instanceof(stream.Writable);
+    assume(transport).instanceof(Writable);
     assume(transport._write).is.a('function');
     // eslint-disable-next-line no-undefined
     assume(transport.log).equals(undefined);


### PR DESCRIPTION
As @ChrisAlderson pointed out, the [`_final` method was introduced in `node@8`](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_writable_final_callback). By moving to the `readable-stream` module as our base we can have this functionality backwards compatible to `node@6`, which is still in LTS. 