### PR TITLE
Add new property to increase default 'highWaterMark' value optionally

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const { LEVEL } = require('triple-beam');
  * @param {Function} options.close - Called on "unpipe" from parent.
  */
 const TransportStream = module.exports = function TransportStream(options = {}) {
-  Writable.call(this, { objectMode: true });
+  Writable.call(this, { objectMode: true, highWaterMark: options.highWaterMark });
 
   this.format = options.format;
   this.level = options.level;


### PR DESCRIPTION
Hi @indexzero, hope you are doing great. This PR is to address one of the issue with **Loggly's nodejs bulk mode logging**. The bulk mode logging used to send **100 events** in a bunch but as per the current scenario in the [readable-stream](https://github.com/nodejs/readable-stream) library, we are restricted to send only **16 events** in a batch because it's a default value set by upstream. 

Code line ref- 
https://github.com/nodejs/readable-stream/blob/3a810302731d74dc71c8803da06f8d4a8a4666d9/lib/internal/streams/state.js#L19-L20


Please make it configurable so that we can set the increased value as per our need to achieve our existing behavior. 

Eagerly waiting for your inputs on this. This is important and critical for us. 

Thanks!