### PR TITLE
Expose LegacyTransportStream on index

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,3 +208,7 @@ TransportStream.prototype._nop = function _nop() {
   // eslint-disable-next-line no-undefined
   return void undefined;
 };
+
+
+// Expose legacy stream
+module.exports.LegacyTransportStream = require('./legacy');


### PR DESCRIPTION
Expose LegacyTransportStream on index to allow bundlers to include the precompiled ES5 file.
This fixes winstonjs/winston#1578

NOTE: Merge together with winstonjs/winston#1640