### PR TITLE
add name to TransportStreamOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare class TransportStream extends stream.Writable {
 
 declare namespace TransportStream {
   interface TransportStreamOptions {
+    name?: string;
     format?: logform.Format;
     level?: string;
     silent?: boolean;


### PR DESCRIPTION
The name attribute is missing in TransportStreamOptions, as a result of which it's not possible to set the TransportInstance name via the constructor in typescript.