### PR TITLE
Fixes for exceptions handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ TransportStream.prototype._write = function _write(info, enc, callback) {
   // any level set on the parent.
   const level = this.level || (this.parent && this.parent.level);
 
-  if (!level || this.levels[level] >= this.levels[info[LEVEL]]) {
+  if (info.exception === true || !level || this.levels[level] >= this.levels[info[LEVEL]]) {
     if (info && !this.format) {
       return this.log(info, callback);
     }

--- a/legacy.js
+++ b/legacy.js
@@ -58,7 +58,7 @@ LegacyTransportStream.prototype._write = function _write(info, enc, callback) {
 
   // Remark: This has to be handled in the base transport now because we
   // cannot conditionally write to our pipe targets as stream.
-  if (!this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
+  if (info.exception === true || !this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
     this.transport.log(info[LEVEL], info.message, info, this._nop);
   }
 

--- a/legacy.js
+++ b/legacy.js
@@ -21,6 +21,7 @@ const LegacyTransportStream = module.exports = function LegacyTransportStream(op
   this.transport = options.transport;
   this.level = this.level || options.transport.level;
   this.handleExceptions = this.handleExceptions || options.transport.handleExceptions;
+  this.exceptionsLevel = this.exceptionsLevel || options.transport.exceptionsLevel;
 
   // Display our deprecation notice.
   this._deprecated();
@@ -59,7 +60,12 @@ LegacyTransportStream.prototype._write = function _write(info, enc, callback) {
   // Remark: This has to be handled in the base transport now because we
   // cannot conditionally write to our pipe targets as stream.
   if (info.exception === true || !this.level || this.levels[this.level] >= this.levels[info[LEVEL]]) {
-    this.transport.log(info[LEVEL], info.message, info, this._nop);
+    this.transport.log(
+        info.exception === true && this.exceptionsLevel ? this.exceptionsLevel : info[LEVEL],
+        info.message,
+        info,
+        this._nop
+    );
   }
 
   callback(null);
@@ -77,7 +83,7 @@ LegacyTransportStream.prototype._writev = function _writev(chunks, callback) {
   for (let i = 0; i < chunks.length; i++) {
     if (this._accept(chunks[i])) {
       this.transport.log(
-        chunks[i].chunk[LEVEL],
+        chunks[i].chunk.exception === true && this.exceptionsLevel ? this.exceptionsLevel : chunks[i].chunk[LEVEL],
         chunks[i].chunk.message,
         chunks[i].chunk,
         this._nop

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -121,7 +121,7 @@ describe('TransportStream', () => {
       expected.forEach(transport.write.bind(transport));
     });
 
-    it('{ level } should be ignored when { handleExceptions: true }', () => {
+    it('{ level } should be ignored when { handleExceptions: true }', done => {
       const expected = testOrder.map(levelAndMessage).map(info => {
         info.exception = true;
         return info;
@@ -129,11 +129,15 @@ describe('TransportStream', () => {
 
       const transport = new TransportStream({
         level: 'info',
+        handleExceptions: true,
         log: logFor(testOrder.length, (err, infos) => {
-          // eslint-disable-next-line no-undefined
-          assume(err).equals(undefined);
+          if (err) {
+            return done(err);
+          }
+
           assume(infos.length).equals(expected.length);
           assume(infos).deep.equals(expected);
+          done();
         })
       });
 


### PR DESCRIPTION
The main intention was to add back support for the `exceptionsLevel` option that (for some reason) had been left out when Winton was restructured in its version 3. Along the way, during the implementation, I have also found an inconsistency in the _write() method regarding exceptions handling that I then decided to fix.