### PR TITLE
Promote logform to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/winstonjs/winston-transport#readme",
   "dependencies": {
+    "logform": "^1.4.0",
     "readable-stream": "^2.3.6",
     "triple-beam": "^1.2.0"
   },
@@ -38,7 +39,6 @@
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "eslint-config-populist": "^4.1.0",
-    "logform": "^1.4.0",
     "mocha": "^5.0.5",
     "nyc": "^11.6.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
It is a full dependency in the Typescript types, so it needs to be in  "dependencies", not "devDependencies".

Fixes #37