### PR TITLE
Added name property to TransportStream

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ import * as stream from 'stream';
 import * as logform from 'logform';
 
 declare class TransportStream extends stream.Writable {
+  public name?: string;
   public format?: logform.Format;
   public level?: string;
   public silent?: boolean;
@@ -24,6 +25,7 @@ declare class TransportStream extends stream.Writable {
 
 declare namespace TransportStream {
   interface TransportStreamOptions {
+    name?: string;
     format?: logform.Format;
     level?: string;
     silent?: boolean;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const { LEVEL } = require('triple-beam');
 const TransportStream = module.exports = function TransportStream(options = {}) {
   Writable.call(this, { objectMode: true, highWaterMark: options.highWaterMark });
 
+  this.name = options.name;
   this.format = options.format;
   this.level = options.level;
   this.handleExceptions = options.handleExceptions;


### PR DESCRIPTION
Added `name` property to `TransportStream` TypeScript type for utilization by users and third-party libraries that have been known to leverage it (like `winston-cloudwatch`). This makes it easy to reference specific transports.

This would be a great addition to `winston-transport` if you all wouldn't mind including it!

At the very least, adding `name` to the TypeScript definitions would be helpful in squelching some errors when utilizing modules that extend `winston`.