### PR TITLE
Relative ref to bin file not needed; npm looks there by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run lint && npm run build",
     "test": "nyc mocha test/*.test.js",
     "report": "nyc report --reporter=lcov",
-    "build": "./node_modules/.bin/rimraf dist && babel *.js -d ./dist",
+    "build": "rimraf dist && babel *.js -d ./dist",
     "prepublishOnly": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
This also helps get around some build system complaints on Windows.