### PR TITLE
Memory leak fix: do not wait for `process.nextTick` to clear pending callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ TransportStream.prototype._write = function _write(info, enc, callback) {
 
     return this.log(transformed, callback);
   }
-
+  this._writableState.sync = false;
   return callback(null);
 };
 


### PR DESCRIPTION
Addresses the memory leak identified here:

https://github.com/winstonjs/winston/issues/1871#issuecomment-1025490757