### PR TITLE
fix write call in unit tests

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,7 @@ describe('TransportStream', () => {
         })
       });
 
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     it('should not log when no info object is provided', done => {
@@ -100,7 +100,7 @@ describe('TransportStream', () => {
         })
       });
 
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     it('should only log messages BELOW the level priority', done => {
@@ -119,7 +119,7 @@ describe('TransportStream', () => {
       });
 
       transport.levels = testLevels;
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     it('{ level } should be ignored when { handleExceptions: true }', () => {
@@ -139,7 +139,7 @@ describe('TransportStream', () => {
       });
 
       transport.levels = testLevels;
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     describe('when { exception: true } in info', () => {
@@ -163,7 +163,7 @@ describe('TransportStream', () => {
           }
         });
 
-        expected.forEach(transport.write.bind(transport));
+        expected.forEach(entry => transport.write.bind(transport)(entry));
       });
 
       it('should invoke log when { handleExceptions: true }', done => {
@@ -190,8 +190,7 @@ describe('TransportStream', () => {
             next();
           }
         });
-
-        expected.forEach(transport.write.bind(transport));
+        expected.forEach(entry => transport.write.bind(transport)(entry));
       });
     });
   });
@@ -223,7 +222,7 @@ describe('TransportStream', () => {
       };
 
       transport.cork();
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
       transport.uncork();
     });
 
@@ -263,7 +262,7 @@ describe('TransportStream', () => {
       };
 
       transport.cork();
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
       transport.uncork();
     });
 
@@ -294,7 +293,7 @@ describe('TransportStream', () => {
       };
 
       transport.cork();
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
       transport.uncork();
     });
 
@@ -324,7 +323,7 @@ describe('TransportStream', () => {
 
       transport.cork();
       transport.levels = testLevels;
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
       transport.uncork();
     });
   });

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -105,7 +105,7 @@ describe('LegacyTransportStream', () => {
         done();
       }));
 
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     it('should only log messages BELOW the level priority', done => {
@@ -126,7 +126,7 @@ describe('LegacyTransportStream', () => {
       }));
 
       transport.levels = testLevels;
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     it('{ level } should be ignored when { handleExceptions: true }', () => {
@@ -147,7 +147,7 @@ describe('LegacyTransportStream', () => {
       }));
 
       transport.levels = testLevels;
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
     });
 
     describe('when { exception: true } in info', () => {
@@ -169,7 +169,7 @@ describe('LegacyTransportStream', () => {
           done();
         });
 
-        expected.forEach(transport.write.bind(transport));
+        expected.forEach(entry => transport.write.bind(transport)(entry));
       });
 
       it('should invoke log when { handleExceptions: true }', done => {
@@ -197,8 +197,7 @@ describe('LegacyTransportStream', () => {
             return done();
           }
         });
-
-        expected.forEach(transport.write.bind(transport));
+        expected.forEach(entry => transport.write.bind(transport)(entry));
       });
     });
   });
@@ -228,7 +227,7 @@ describe('LegacyTransportStream', () => {
       };
 
       transport.cork();
-      expected.forEach(transport.write.bind(transport));
+      expected.forEach(entry => transport.write.bind(transport)(entry));
       transport.uncork();
     });
   });


### PR DESCRIPTION
I tried updating the package `readable-stream` to `4.5.2` and noticed that some unit tests are failing. That is because `transport.write` is called with additional parameters from `forEach`.
`forEach` passes three parameters to its callback ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#parameters)): `element`, `index` and `array`. `write` should only receive `element`, but previously, it also received `index` as `enc` and `array` as `callback`.
This PR changes this, so that only `element` is provided.

I would like to see readable-stream updated and can provide a PR for that. I think dependabot already tried that and failed, maybe because the tests failed.